### PR TITLE
Add ground item highlighting for profitable alchs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -81,9 +81,12 @@ public class GroundItemsOverlay extends Overlay
 		this.config = config;
 		this.itemManager = itemManager;
 
-		try {
+		try
+		{
 			natureRunePrice = itemManager.getItemPrice(561).getPrice();
-		} catch (IOException e) {
+		}
+		catch (IOException e)
+		{
 			e.printStackTrace();
 		}
 	}


### PR DESCRIPTION
Added a new option to the ground items plugin that allows you to highlight items that are profitable to high alch instead of selling on the Grand Exchange